### PR TITLE
Improve / fix bullet tracers

### DIFF
--- a/lua/weapons/bobs_gun_base/shared.lua
+++ b/lua/weapons/bobs_gun_base/shared.lua
@@ -358,7 +358,7 @@ function SWEP:BulletPenetrate( iteration, attacker, bulletTrace, dmginfo, direct
         end
     } )
 
-    debugoverlay.Line( bulletTrace.HitPos + penDirection, penTrace.HitPos, 10, Color( 255, 0, 0 ), true )
+    --debugoverlay.Line( bulletTrace.HitPos + penDirection, penTrace.HitPos, 10, Color( 255, 0, 0 ), true )
 
     if penTrace.AllSolid and penTrace.HitWorld then return false end
     if not penTrace.Hit then return false end
@@ -447,7 +447,7 @@ function SWEP:BulletRicochet( iteration, attacker, bulletTrace, dmginfo, directi
         end
     }
 
-    debugoverlay.Line( bulletTrace.HitPos, bulletTrace.HitPos + bullet.Dir * 100, 10, SERVER and Color( 255, 0, 0 ) or Color( 0, 255, 0 ), true )
+    --debugoverlay.Line( bulletTrace.HitPos, bulletTrace.HitPos + bullet.Dir * 100, 10, SERVER and Color( 255, 0, 0 ) or Color( 0, 255, 0 ), true )
 
     timer.Simple( 0, function()
         attacker:FireBullets( bullet )

--- a/lua/weapons/bobs_gun_base/shared.lua
+++ b/lua/weapons/bobs_gun_base/shared.lua
@@ -325,7 +325,7 @@ local easyPenMaterials = {
 local spreadVec = Vector( 0, 0, 0 )
 
 function SWEP:BulletCallback( iteration, attacker, bulletTrace, dmginfo, direction )
-    if not IsFirstTimePredicted() then return end
+    if CLIENT then return end
     if bulletTrace.HitSky then return end
 
     iteration = iteration and iteration + 1 or 0
@@ -336,8 +336,6 @@ function SWEP:BulletCallback( iteration, attacker, bulletTrace, dmginfo, directi
 
     local penetrated = self:BulletPenetrate( iteration, attacker, bulletTrace, dmginfo, direction )
     if penetrated then return end
-
-    if CLIENT then return end -- Only penetration effects need to be done clientside
 
     local ricochet = self:BulletRicochet( iteration, attacker, bulletTrace, dmginfo, direction )
     if ricochet then return end
@@ -373,7 +371,7 @@ function SWEP:BulletPenetrate( iteration, attacker, bulletTrace, dmginfo, direct
         Src = penTrace.HitPos,
         Dir = direction,
         Spread = spreadVec,
-        Tracer = 2,
+        Tracer = 1,
         TracerName = "m9k_effect_mad_penetration_trace",
         Force = 5,
         Damage = dmginfo:GetDamage() * damageMult,


### PR DESCRIPTION
After looking through how tracers are handled i've noticed some mistakes i made before, this pr aims to fix it by always allowing bullet effects to play as bullets are fired when needed.