### PR TITLE
Dont apply scope zoom sens effect when sprinting

### DIFF
--- a/lua/weapons/bobs_scoped_base/shared.lua
+++ b/lua/weapons/bobs_scoped_base/shared.lua
@@ -437,6 +437,7 @@ end
 function SWEP:AdjustMouseSensitivity()
     local owner = self:GetOwner()
     if owner:KeyDown( IN_SPEED ) then return end
+    if not self:GetIronsights() then return end
 
     if owner:KeyDown( IN_ATTACK2 ) then
         return 1 / ( self.Secondary.ScopeZoom / 2 )

--- a/lua/weapons/bobs_scoped_base/shared.lua
+++ b/lua/weapons/bobs_scoped_base/shared.lua
@@ -435,9 +435,10 @@ function SWEP:DrawHUD()
 end
 
 function SWEP:AdjustMouseSensitivity()
-    if self:GetOwner():KeyDown( IN_ATTACK2 ) then
-        return (1 / (self.Secondary.ScopeZoom / 2))
-    else
-        return 1
+    local owner = self:GetOwner()
+    if owner:KeyDown( IN_SPEED ) then return end
+
+    if owner:KeyDown( IN_ATTACK2 ) then
+        return 1 / ( self.Secondary.ScopeZoom / 2 )
     end
 end


### PR DESCRIPTION
Fixes a bug where holding right click while holding a sniper lowers your sensitivity