### PR TITLE
Remove duplicate fireeffects usage

### DIFF
--- a/lua/weapons/bobs_gun_base/shared.lua
+++ b/lua/weapons/bobs_gun_base/shared.lua
@@ -466,8 +466,6 @@ function SWEP:ShootBullet( damage, recoil, num_bullets, aimcone )
     num_bullets = num_bullets or 1
     aimcone = aimcone or 0
 
-    self:ShootEffects()
-
     if self.Tracer == 1 then
         TracerName = "Ar2Tracer"
     elseif self.Tracer == 2 then


### PR DESCRIPTION
Removes :ShootEffects() https://wiki.facepunch.com/gmod/WEAPON:ShootEffects
As this is already handled in SWEP:PrimaryAttack()