### PR TITLE
shifted boltaction logic to rely on rpm

### DIFF
--- a/lua/weapons/bobs_scoped_base/shared.lua
+++ b/lua/weapons/bobs_scoped_base/shared.lua
@@ -173,8 +173,8 @@ function SWEP:BoltBack()
                 self:GetOwner():DrawViewModel( true )
             end
 
-            local boltactiontime = (self:GetOwner():GetViewModel():SequenceDuration())
-            timer.Simple( boltactiontime + .1, function()
+            local boltactiontime = (1 / (self.Primary.RPM / 60))
+            timer.Simple( boltactiontime - 0.2, function()
                 if not IsValid( self ) or not IsValid( self:GetOwner() ) then return end
                 self:SetReloading( false )
                 if self:GetOwner():KeyDown( IN_ATTACK2 ) then


### PR DESCRIPTION
shifted the bolt action behavior for m9k to instead rely on the rpm of the weapon rather than the sequence length of the firing animation, this caused several inconsistencies and wonky behaviors, like sometimes not even leaving the scope between shots, not scoping in at all before a shot is fired despite scoping in on consecutive shots, having too high of an rpm causing a ton of issues with descoping and rescoping becoming out of sync and so on

relying on rpm makes this incredibly consistent and less janky overall