### PR TITLE
truncate 3 instead of 2

### DIFF
--- a/lua/weapons/bobs_gun_base.lua
+++ b/lua/weapons/bobs_gun_base.lua
@@ -918,7 +918,7 @@ if CLIENT then
             local easer = math.ease.OutCubic( self.RecoilRecoverySpeed * ( CurTime() - self.PrevThinkBlowback ) )
 
             if easer ~= self.RecoilAmount then
-                self.RecoilAmount = math.Truncate( Lerp( easer, self.RecoilAmount, 0 ), 2 ) --truncated so the value actually returns to zero
+                self.RecoilAmount = math.Truncate( Lerp( easer, self.RecoilAmount, 0 ), 3 ) --truncated so the value actually returns to zero
             end
         end
 


### PR DESCRIPTION
results in better behavior whilst still ensuring the value returns to 0