### PR TITLE
Make grenades respect RPM

### DIFF
--- a/lua/weapons/bobs_nade_base.lua
+++ b/lua/weapons/bobs_nade_base.lua
@@ -128,3 +128,19 @@ end
 
 function SWEP:SecondaryAttack()
 end
+
+function SWEP:Deploy()
+    self:SetIronsights( false )
+    self.DrawCrosshair = self.OrigCrossHair
+    self:SetHoldType( self.HoldType )
+
+    if not self:GetReloading() then
+        self:SendWeaponAnim( ACT_VM_DRAW )
+
+        if self.DeployDelay then
+            self:SetNextPrimaryFire( CurTime() + self.DeployDelay )
+        end
+    end
+
+    return true
+end

--- a/lua/weapons/bobs_nade_base.lua
+++ b/lua/weapons/bobs_nade_base.lua
@@ -116,8 +116,10 @@ function SWEP:Throw()
 
             if self:Clip1() == 0 and owner:GetAmmoCount( self:GetPrimaryAmmoType() ) == 0 then
                 owner:StripWeapon( self.Gun )
-            else
+            elseif owner:GetActiveWeapon() == self then
                 self:DefaultReload( ACT_VM_DRAW )
+            else
+                self:SetReloading( false )
             end
         end )
     end )
@@ -135,7 +137,11 @@ function SWEP:Deploy()
     self:SetHoldType( self.HoldType )
 
     if not self:GetReloading() then
-        self:SendWeaponAnim( ACT_VM_DRAW )
+        if self:Clip1() == 0 then
+            self:DefaultReload( ACT_VM_DRAW )
+        else
+            self:SendWeaponAnim( ACT_VM_DRAW )
+        end
 
         if self.DeployDelay then
             self:SetNextPrimaryFire( CurTime() + self.DeployDelay )

--- a/lua/weapons/bobs_nade_base.lua
+++ b/lua/weapons/bobs_nade_base.lua
@@ -78,6 +78,7 @@ end
 function SWEP:Throw()
     local owner = self:GetOwner()
 
+    self:SetReloading( true ) -- Prevent players from manually reloading to skip the RPM cooldown
     self:SendWeaponAnim( ACT_VM_THROW )
     timer.Simple( 0.35, function()
         if not IsValid( self ) then return end
@@ -109,7 +110,7 @@ function SWEP:Throw()
 
         self:TakePrimaryAmmo( 1 )
 
-        timer.Simple( 0.15, function()
+        timer.Simple( self:GetNextPrimaryFire() - CurTime(), function()
             if not IsValid( self ) then return end
             if not IsValid( owner ) then return end
 


### PR DESCRIPTION
Makes grenades respect SWEP.Primary.RPM cooldowns, instead of having fire rate tied to the weapon animations.