### PR TITLE
fix ironsights bugging during reload

### DIFF
--- a/lua/weapons/bobs_gun_base.lua
+++ b/lua/weapons/bobs_gun_base.lua
@@ -827,7 +827,7 @@ function SWEP:Reload()
 
         self:SetReloading( false )
 
-        if owner:KeyDown( IN_ATTACK2 ) and self.Scoped == false then
+        if not owner:KeyDown( IN_SPEED ) and owner:KeyDown( IN_ATTACK2 ) and self.Scoped == false then
             owner:SetFOV( self.Secondary.IronFOV, self.IronSightTime )
             self.IronSightsPos = self.SightsPos -- Bring it up
             self.IronSightsAng = self.SightsAng -- Bring it up

--- a/lua/weapons/bobs_scoped_base/shared.lua
+++ b/lua/weapons/bobs_scoped_base/shared.lua
@@ -233,6 +233,20 @@ function SWEP:Reload()
         if not IsValid( self ) or not IsValid( owner ) then return end
 
         self:SetReloading( false )
+        
+        if owner:KeyDown( IN_SPEED ) then
+            if self:GetNextPrimaryFire() <= ( CurTime() + 0.3 ) then
+                self:SetNextPrimaryFire( CurTime() + 0.3 ) -- Make it so you can't shoot for another quarter second
+            end
+            self.IronSightsPos = self.RunSightsPos -- Hold it down
+            self.IronSightsAng = self.RunSightsAng -- Hold it down
+            self:SetIronsights( false )
+            self:SetDrawViewmodel( true )
+            owner:SetFOV( 0, 0.2 )
+
+            return
+        end
+        
         if owner:KeyDown( IN_ATTACK2 ) then
             owner:SetFOV( 75 / self.Secondary.ScopeZoom, 0.15 )
             self.IronSightsPos = self.SightsPos -- Bring it up
@@ -240,14 +254,6 @@ function SWEP:Reload()
             self.DrawCrosshair = false
             self:SetIronsights( true )
             self:SetDrawViewmodel( false )
-        elseif owner:KeyDown( IN_SPEED ) then
-            if self:GetNextPrimaryFire() <= ( CurTime() + 0.3 ) then
-                self:SetNextPrimaryFire( CurTime() + 0.3 ) -- Make it so you can't shoot for another quarter second
-            end
-            self.IronSightsPos = self.RunSightsPos -- Hold it down
-            self.IronSightsAng = self.RunSightsAng -- Hold it down
-            self:SetIronsights( true )
-            owner:SetFOV( 0, 0.2 )
         end
     end )
 end

--- a/lua/weapons/m9k_contender.lua
+++ b/lua/weapons/m9k_contender.lua
@@ -110,6 +110,20 @@ function SWEP:UseBolt()
         timer.Simple( boltactiontime, function()
             if not IsValid( self ) or not IsValid( owner ) then return end
             self:SetReloading( false )
+
+            if owner:KeyDown( IN_SPEED ) then
+                self.IronSightsPos = self.RunSightsPos -- Hold it down
+                self.IronSightsAng = self.RunSightsAng -- Hold it down
+                self:SetIronsights( false )
+                self:SetDrawViewmodel( true )
+                owner:SetFOV( 0, 0.3 )
+                owner:RemoveAmmo( 1, self.Primary.Ammo, false )
+                self:SetClip1( self:Clip1() + 1 )
+                self:SetNextPrimaryFire( CurTime() + .1 )
+
+                return
+            end
+
             if owner:KeyDown( IN_ATTACK2 ) then
                 owner:SetFOV( 75 / self.Secondary.ScopeZoom, 0.15 )
                 self.IronSightsPos = self.SightsPos -- Bring it up
@@ -169,9 +183,22 @@ function SWEP:Reload()
                 self:SetReloading( true )
             end
             local waitdammit = owner:GetViewModel():SequenceDuration()
-            timer.Simple( waitdammit, function()
+            timer.Simple( waitdammit + .1, function()
                 if not IsValid( self ) then return end
                 self:SetReloading( false )
+
+                if owner:KeyDown( IN_SPEED ) then
+                    if self:GetNextPrimaryFire() <= (CurTime() + .03) then
+                        self:SetNextPrimaryFire( CurTime() + 0.3 ) -- Make it so you can't shoot for another quarter second
+                    end
+                    self.IronSightsPos = self.RunSightsPos -- Hold it down
+                    self.IronSightsAng = self.RunSightsAng -- Hold it down
+                    self:SetIronsights( false )
+                    self:SetDrawViewmodel( true )
+                    owner:SetFOV( 120, 0.3 )
+
+                    return
+                end
 
                 if owner:KeyDown( IN_ATTACK2 ) then
                     if CLIENT then return end
@@ -182,14 +209,6 @@ function SWEP:Reload()
                         self:SetIronsights( true )
                         self.DrawCrosshair = false
                     end
-                elseif owner:KeyDown( IN_SPEED ) then
-                    if self:GetNextPrimaryFire() <= (CurTime() + .03) then
-                        self:SetNextPrimaryFire( CurTime() + 0.3 ) -- Make it so you can't shoot for another quarter second
-                    end
-                    self.IronSightsPos = self.RunSightsPos -- Hold it down
-                    self.IronSightsAng = self.RunSightsAng -- Hold it down
-                    self:SetIronsights( true )
-                    owner:SetFOV( 0, 0.3 )
                 end
             end )
         end

--- a/lua/weapons/m9k_m202.lua
+++ b/lua/weapons/m9k_m202.lua
@@ -122,6 +122,17 @@ function SWEP:Reload()
                 if IsValid( self ) and IsValid( owner ) then
                     if owner:Alive() and owner:GetActiveWeapon():GetClass() == self.Gun then
                         self:SetReloading( false )
+
+                        if owner:KeyDown( IN_SPEED ) then
+                            self:SetNextPrimaryFire( CurTime() + 0.3 ) -- Make it so you can't shoot for another quarter second
+                            self.IronSightsPos = self.RunSightsPos -- Hold it down
+                            self.IronSightsAng = self.RunSightsAng -- Hold it down
+                            self:SetIronsights( true )
+                            owner:SetFOV( 0, 0.3 )
+
+                            return
+                        end
+
                         if owner:KeyDown( IN_ATTACK2 ) then
                             if CLIENT then return end
                             if self.Scoped == false then
@@ -133,14 +144,6 @@ function SWEP:Reload()
                             else
                                 return
                             end
-                        elseif owner:KeyDown( IN_SPEED ) then
-                            self:SetNextPrimaryFire( CurTime() + 0.3 ) -- Make it so you can't shoot for another quarter second
-                            self.IronSightsPos = self.RunSightsPos -- Hold it down
-                            self.IronSightsAng = self.RunSightsAng -- Hold it down
-                            self:SetIronsights( true )
-                            owner:SetFOV( 0, 0.3 )
-                        else
-                            return
                         end
                     end
                 end

--- a/lua/weapons/m9k_usas.lua
+++ b/lua/weapons/m9k_usas.lua
@@ -128,18 +128,23 @@ function SWEP:ReloadFinish()
         if not IsValid( self ) then return end
         if not IsValid( owner ) then return end
         self:SetReloading( false )
+
+        if owner:KeyDown( IN_SPEED ) then
+            self:SetNextPrimaryFire( CurTime() + 0.3 )
+            self.IronSightsPos = self.RunSightsPos
+            self.IronSightsAng = self.RunSightsAng
+            self:SetIronsights( true )
+            owner:SetFOV( 0, 0.3 )
+
+            return
+        end
+
         if owner:KeyDown( IN_ATTACK2 ) and self.Scoped == false then
             owner:SetFOV( self.Secondary.IronFOV, 0.3 )
             self.IronSightsPos = self.SightsPos
             self.IronSightsAng = self.SightsAng
             self:SetIronsights( true, owner )
             self.DrawCrosshair = false
-        elseif owner:KeyDown( IN_SPEED ) then
-            self:SetNextPrimaryFire( CurTime() + 0.3 )
-            self.IronSightsPos = self.RunSightsPos
-            self.IronSightsAng = self.RunSightsAng
-            self:SetIronsights( true )
-            owner:SetFOV( 0, 0.3 )
         end
     end )
 end


### PR DESCRIPTION
Before: https://cdn.steamusercontent.com/ugc/15095282683054171873/057E2268F4B5CB8A55A3A8EEE70616DA9419B3C3/

After: https://cdn.steamusercontent.com/ugc/15004013134516575800/3250F6198274F161CB23476196BD205A325584D5/

Basically, your fov would fuck up when aiming and reloading while sprinting. I moved the check for running to go before checking if you were aiming during reload.