### PR TITLE
Recoil rework

### DIFF
--- a/lua/weapons/bobs_gun_base.lua
+++ b/lua/weapons/bobs_gun_base.lua
@@ -804,8 +804,9 @@ function SWEP:ShootBullet( damage, bulletCount, aimcone )
         recoilYaw = recoilYaw * 0.5
     end
 
-    recoilPitch = recoilPitch * 0.9
-    recoilYaw = recoilYaw * 0.9
+    -- Adjust old viewpunch based numbers for the new recoil system
+    recoilPitch = recoilPitch * 0.75
+    recoilYaw = recoilYaw * 0.75
 
     self:SetRecoilPitch( recoilPitch )
     self:SetRecoilYaw( recoilYaw )


### PR DESCRIPTION
Makes the recoil logic use :SetEyeAngles instead of ViewPunch

This fixes some prediction issues and improves hitreg while also removing downwards movement

For reference:

Old:
<img width="1077" height="949" alt="image" src="https://github.com/user-attachments/assets/d44dce23-ad35-44cc-a7b0-ca270bfb9edf" />


New:
<img width="1191" height="1028" alt="image" src="https://github.com/user-attachments/assets/190f2a83-b24d-41ac-ac24-4231009904a2" />
