### PR TITLE
Fix orbital strike sound

### DIFF
--- a/lua/entities/m9k_oribital_cannon.lua
+++ b/lua/entities/m9k_oribital_cannon.lua
@@ -298,7 +298,7 @@ if SERVER then
         timer.Simple( 1.5, function()
             for k, v in ipairs( player.GetAll() ) do
                 if IsValid( v ) then
-                    v:EmitSound( "npc/strider/fire.ogg" )
+                    v:EmitSound( "npc/strider/fire.wav" )
                     --sound.Play("npc/strider/fire.ogg", v:GetPos(), 100, 100, 1)
                 end
             end


### PR DESCRIPTION
After converting sounds to `.ogg`, you accidentally converted the default strider sound to ogg, breaking the main part of the orbital strike sound