### PR TITLE
Fix sniper ammo language string

### DIFF
--- a/lua/autorun/m9k_ammotypes.lua
+++ b/lua/autorun/m9k_ammotypes.lua
@@ -14,7 +14,7 @@ game.AddAmmoType( { name = "rpg_rocket", dmgtype = DMG_BLAST } )
 
 if CLIENT then
     list.Set( "ContentCategoryIcons", "M9K Ammunition", "icon16/box.png" )
-    language.Add( "SniperPenetratedRound", "Sniper Ammo" )
+    language.Add( "SniperPenetratedRound_ammo", "Sniper Ammo" )
     language.Add( "40mmGrenade_ammo", "40mm Grenade" )
     language.Add( "C4Explosive_ammo", "C4" )
     language.Add( "ProxMine_ammo", "Proximity Mine" )


### PR DESCRIPTION
I forgot to add the '_ammo', so the previous fix didn't work