### PR TITLE
use pistol holdtype instead of fist

### DIFF
--- a/lua/weapons/m9k_ied_detonator.lua
+++ b/lua/weapons/m9k_ied_detonator.lua
@@ -16,7 +16,7 @@ SWEP.DrawCrosshair          = false -- set false if you want no crosshair
 SWEP.Weight                 = 2
 SWEP.AutoSwitchTo           = true
 SWEP.AutoSwitchFrom         = true
-SWEP.HoldType               = "fist"
+SWEP.HoldType               = "pistol"
 
 
 


### PR DESCRIPTION
It makes more sense to hold a phone like this:
<img width="583" height="455" alt="image" src="https://github.com/user-attachments/assets/95e7eca0-a3a4-44a1-a7f1-e9ea738f78f9" />


than like this:
<img width="487" height="432" alt="image" src="https://github.com/user-attachments/assets/be124522-0553-48aa-831c-1b221ba42afa" />

