### PR TITLE
Try to fix explosions that play sometimes without sound

### DIFF
--- a/lua/effects/m9k_gdcw_cinematicboom/init.lua
+++ b/lua/effects/m9k_gdcw_cinematicboom/init.lua
@@ -37,15 +37,8 @@ function EFFECT:Init( data )
     self.DebrizzlemyNizzle = 10 + data:GetScale() -- Debrizzle my Nizzle is how many "trails" to make			--
     self.Size = 5 * self.Scale -- Size is exclusively for the explosion "trails" size			--
     self.Emitter = ParticleEmitter( self.Pos ) -- Emitter must be there so you don't get an error			--
-    self.PlaySound = data:GetHitBox() ~= 3 -- PlaySound determines whether to play sound or not		--
 
-    if self.PlaySound then
-        if self.Scale < 1.2 then
-            sound.Play( "ambient/explosions/explode_" .. math.random( 1, 4 ) .. ".wav", self.Pos, 100, 100 )
-        else
-            sound.Play( "ambient/explosions/explode_" .. math.random( 1, 4 ) .. ".wav", self.Pos, 100, 100 )
-        end
-    end
+    sound.Play( "ambient/explosions/explode_" .. math.random( 1, 4 ) .. ".wav", self.Pos, 100, 100 )
 
     local mat = math.ceil( self.Radius )
     local foundTheMat = false

--- a/lua/entities/m9k_thrown_nitrox.lua
+++ b/lua/entities/m9k_thrown_nitrox.lua
@@ -75,7 +75,6 @@ PhysicsCollide
         effectdata:SetScale( self.ExplosionEffectScale )
         effectdata:SetRadius( 67 )
         effectdata:SetMagnitude( self.ExplosionEffectMagnitude )
-        effectdata:SetHitBox( 3 )
         util.Effect( "m9k_gdcw_cinematicboom", effectdata )
         util.BlastDamage( self, owner, pos, self.ExplosionRadius, self.ExplosionDamage )
         util.ScreenShake( pos, 500, 500, .25, 500 )


### PR DESCRIPTION
It's probably because of this weird `data:GetHitbox ~= 3` check that just doesn't work for some reason? The sound should always play anyways, so this can be removed